### PR TITLE
Modify API_KEY assignment to use environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The shim will:
 - Update `~/.claude/settings.json` with the correct `ANTHROPIC_BASE_URL`
 - Run health checks to verify connectivity
 
-> If your ALCF username differs from your CELS username, hardcode `API_KEY` at the top of the script.
+> If your ALCF username differs from your CELS username, set `CELS_USERNAME` to your CELS username
 
 **2. Start Claude Code** (in another terminal on the same node)
 

--- a/argo_shim.py
+++ b/argo_shim.py
@@ -15,7 +15,7 @@ BASE_LISTEN_PORT = 8081
 MAX_PORT_RETRIES = 10
 TARGET_HOST = "127.0.0.1"
 REAL_HOST = "apps.inside.anl.gov"
-API_KEY = getpass.getuser()
+API_KEY = os.environ.get("CELS_USERNAME", getpass.getuser())
 SSH_JUMP_HOST = "homes.cels.anl.gov"
 SSH_PROXY_JUMP = "logins.cels.anl.gov"
 


### PR DESCRIPTION
Usefull for people where their alcf username are not their cells one.

So no need to modify the shim, will make updating / git pull easier for those user (aka me :P )