### PR TITLE
Adding a troubleshooting issue related to HTTP_PROXY being set

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,10 @@ kill <pid>
 **Claude Code can't connect after restarting the shim**
 
 The shim port may have changed. The shim updates `~/.claude/settings.json` automatically, but you need to restart Claude Code to pick up the new port.
+
+**"ERROR: The requested URL could not be retrieved" in Claude Code**
+
+If you see the above in Claude Code after sending a prompt, you may need to unset some HTTP proxies.
+In particular, see if HTTP_PROXY is set, and unset it. (In the past ANL has
+recommended `export HTTP_PROXY="http://proxy.alcf.anl.gov:3128"`. This setting can cause
+the issue.)


### PR DESCRIPTION
This modifies the README to add an issue we ran into when testing. If HTTP_PROXY is set (which we used to recommend to people for Aurora and which I had in my bashrc) Claude Code will fail to respond to prompts, and error out with `ERROR: The requested URL could not be retrieved`.