### PR TITLE
Fix proxy handling, bind-address checks, and add CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv build
+      - run: uv publish

--- a/README.md
+++ b/README.md
@@ -197,3 +197,17 @@ unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
 ```
 
 See the [ALCF proxy docs](https://docs.alcf.anl.gov/aurora/getting-started-on-aurora/#proxy) for more details on proxy settings on Aurora login nodes.
+
+## Publishing to PyPI
+
+Publishing is automated via GitHub Actions. To release a new version:
+
+1. Bump the version in `argo_shim/__init__.py`
+2. Commit and tag:
+   ```bash
+   git commit -am "Bump version to X.Y.Z"
+   git tag vX.Y.Z
+   git push && git push --tags
+   ```
+
+The workflow builds with `uv build` and publishes with `uv publish` using [trusted publishing](https://docs.pypi.org/trusted-publishers/) (no API tokens needed — configure the GitHub repo as a trusted publisher on PyPI).

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ This creates an SSH tunnel bound to all interfaces and prints the command to run
 argo-shim --tunnel-host <uan-hostname>
 ```
 
-Then start Claude Code:
+Then start Claude Code. If proxy env vars are set (common on HPC nodes), bypass them for localhost:
 
 ```bash
-claude
+no_proxy=localhost,127.0.0.1 NO_PROXY=localhost,127.0.0.1 claude
 ```
 
-The shim automatically sets `no_proxy=localhost,127.0.0.1` in `~/.claude/settings.json` so API traffic bypasses the institutional proxy while internet access (web fetches, package installs) still works.
+The shim prints this command automatically when it detects proxy variables. Without `no_proxy`, the proxy intercepts API traffic to `127.0.0.1` and breaks the connection.
 
 ### Fallback: Relay through your Mac
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Then start Claude Code:
 claude
 ```
 
-The shim automatically clears proxy environment variables in `~/.claude/settings.json`, so no manual unsetting is needed.
+The shim automatically sets `no_proxy=localhost,127.0.0.1` in `~/.claude/settings.json` so API traffic bypasses the institutional proxy while internet access (web fetches, package installs) still works.
 
 ### Fallback: Relay through your Mac
 
@@ -184,19 +184,9 @@ The shim works around this by forcing `stream: true` on all POST requests to `/m
 
 **"ERROR: The requested URL could not be retrieved" in Claude Code**
 
-HPC login nodes often set `HTTP_PROXY` / `HTTPS_PROXY` environment variables that route traffic through an institutional proxy, bypassing the shim's localhost proxy entirely. Clear them when launching Claude Code:
+HPC login nodes set `HTTP_PROXY` / `HTTPS_PROXY` environment variables that can interfere with the shim's localhost proxy. The shim handles this automatically by setting `no_proxy=localhost,127.0.0.1` in Claude Code's settings, so API traffic bypasses the proxy while internet access still works.
 
-```bash
-HTTP_PROXY= HTTPS_PROXY= http_proxy= https_proxy= claude
-```
-
-To make this permanent, unset the proxy vars in your shell config (e.g., `~/.bashrc`):
-
-```bash
-unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
-```
-
-See the [ALCF proxy docs](https://docs.alcf.anl.gov/aurora/getting-started-on-aurora/#proxy) for more details on proxy settings on Aurora login nodes.
+If you still see proxy errors, ensure you're running the latest version of the shim. See the [ALCF proxy docs](https://docs.alcf.anl.gov/aurora/getting-started-on-aurora/#proxy) for more details.
 
 ## Publishing to PyPI
 

--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -347,6 +347,10 @@ def update_claude_settings(listen_port, auth_token):
     env["ANTHROPIC_BASE_URL"] = new_url
     # Bypass proxy for localhost (argo-shim) while preserving proxy for
     # internet access (web fetches, package installs, etc.)
+    # Clean up stale empty proxy vars from older versions of argo-shim
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+        if var in env and env[var] == "":
+            del env[var]
     for var in ("no_proxy", "NO_PROXY"):
         existing = env.get(var, "")
         hosts = [h.strip() for h in existing.split(",") if h.strip()] if existing else []

--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -345,8 +345,15 @@ def update_claude_settings(listen_port, auth_token):
         settings["apiKeyHelper"] = "echo no-auth"
     env = settings.setdefault("env", {})
     env["ANTHROPIC_BASE_URL"] = new_url
-    for var in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
-        env[var] = ""
+    # Bypass proxy for localhost (argo-shim) while preserving proxy for
+    # internet access (web fetches, package installs, etc.)
+    for var in ("no_proxy", "NO_PROXY"):
+        existing = env.get(var, "")
+        hosts = [h.strip() for h in existing.split(",") if h.strip()] if existing else []
+        for h in ("localhost", "127.0.0.1"):
+            if h not in hosts:
+                hosts.append(h)
+        env[var] = ",".join(hosts)
 
     with open(settings_path, "w") as f:
         json.dump(settings, f, indent=2)

--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -523,7 +523,9 @@ def main():
     tunnel_is_remote = bool(args.tunnel_host)
     with ThreadedTCPServer(("127.0.0.1", listen_port), ProxyHandler, tunnel_host, tunnel_port, auth_token, tunnel_is_remote) as httpd:
         print(f"✅ Shim running on {listen_port} -> {tunnel_port}. Supports GET/POST/HEAD.")
-        if os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy"):
+        proxy_set = any(os.environ.get(v) for v in ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"))
+        no_proxy_hosts = (os.environ.get("NO_PROXY", "") + "," + os.environ.get("no_proxy", "")).strip(",")
+        if proxy_set and not any(h in no_proxy_hosts for h in ("localhost", "127.0.0.1")):
             print(f"\nProxy detected. Start Claude Code with:")
             print(f"  no_proxy=localhost,127.0.0.1 NO_PROXY=localhost,127.0.0.1 claude")
 

--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -177,7 +177,7 @@ class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     def recover_tunnel(self):
         """Attempt to recreate the SSH tunnel. Returns True if recovery succeeded."""
         if self.tunnel_is_remote:
-            # Remote tunnel (--tunnel-host / --relay): can't recreate from here
+            # Remote tunnel (--tunnel-host): can't recreate from here
             print("Tunnel is remote — cannot recover locally. Check the relay or UAN.")
             return False
         with self._tunnel_lock:
@@ -276,7 +276,7 @@ def find_existing_tunnel(port, host="127.0.0.1"):
 
 def create_tunnel(port, host="127.0.0.1", bind_address="127.0.0.1"):
     """Create a new SSH tunnel on the given port and verify it's working."""
-    check_port_available(port, host)
+    check_port_available(port, bind_address)
     cmd = [
         "ssh", "-N", "-f",
         "-o", "ServerAliveInterval=15",

--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -523,6 +523,9 @@ def main():
     tunnel_is_remote = bool(args.tunnel_host)
     with ThreadedTCPServer(("127.0.0.1", listen_port), ProxyHandler, tunnel_host, tunnel_port, auth_token, tunnel_is_remote) as httpd:
         print(f"✅ Shim running on {listen_port} -> {tunnel_port}. Supports GET/POST/HEAD.")
+        if os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy"):
+            print(f"\nProxy detected. Start Claude Code with:")
+            print(f"  no_proxy=localhost,127.0.0.1 NO_PROXY=localhost,127.0.0.1 claude")
 
         def shutdown_handler(signum, frame):
             signame = signal.Signals(signum).name


### PR DESCRIPTION
## Summary

- Fix `check_port_available` to use `bind_address` instead of `host`, so 0.0.0.0-bound tunnels are checked correctly
- Fix `recover_tunnel` comment (remove stale --relay mention)
- Use `no_proxy=localhost,127.0.0.1` instead of clearing proxy vars — preserves internet access for web fetches and package installs on HPC compute nodes
- Clean up stale empty proxy vars (`HTTP_PROXY=""`) left by older versions
- Print `no_proxy` launch hint when proxy env vars are detected
- Add GitHub Actions workflow for PyPI publishing via `uv publish` on version tags

## Test plan

- [ ] Run `argo-shim` on a node with proxy env vars set, verify it prints the `no_proxy` launch hint
- [ ] Verify `~/.claude/settings.json` has `no_proxy` entries and no empty proxy vars
- [ ] Run Claude Code with `no_proxy=localhost,127.0.0.1` and confirm both API and web access work
- [ ] Run `argo-shim --tunnel` and verify `find_existing_tunnel` detects 0.0.0.0-bound tunnels on restart