### PR TITLE
feat: accept bearer auth + auto-inject user for OpenAI/Gemini models

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,29 @@ To use a specific model (e.g., Opus), add a `"model"` field to your settings:
 
 Without this, Claude Code defaults to Sonnet.
 
+## OpenAI-compatible clients
+
+The shim isn't just for Claude Code — any OpenAI- or Anthropic-format client can
+use it:
+
+- **Authentication.** In addition to `x-api-key`, the shim accepts the shim
+  token via `Authorization: Bearer <token>`, so OpenAI SDKs / clients that only
+  send a bearer token work without modification.
+- **OpenAI & Gemini models.** Argo serves these on
+  `/argoapi/v1/chat/completions` and requires a `user` field set to a valid
+  ALCF username, or it returns `HTTP 500`. The shim auto-injects this for any
+  `/chat/completions` request that doesn't already set `user`. The value is
+  resolved from `$ARGO_USER`, then `$CELS_USERNAME`, then your login username —
+  set `ARGO_USER` if your ALCF username differs.
+
+```bash
+# OpenAI-format request via bearer auth (user field auto-injected by the shim)
+curl http://127.0.0.1:<shim-port>/argoapi/v1/chat/completions \
+     -H "Authorization: Bearer <auth-token>" \
+     -H "content-type: application/json" \
+     -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}'
+```
+
 ## Health Checks
 
 The shim runs these automatically on startup. To run them manually:

--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -460,7 +460,7 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             if method != "HEAD" and client_key != self.server.auth_token:
                 self.send_response(401)
                 self.send_header('Content-Type', 'text/plain')
-                msg = b'Unauthorized: invalid or missing x-api-key'
+                msg = b'Unauthorized: invalid or missing x-api-key (or Authorization: Bearer token)'
                 self.send_header('Content-Length', str(len(msg)))
                 self.end_headers()
                 self.wfile.write(msg)
@@ -522,12 +522,19 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
         if method == "POST" and body and "/chat/completions" in self.path:
             try:
                 req_json = json.loads(body)
-                if not req_json.get("user"):
-                    req_json["user"] = ARGO_USER
-                    body = json.dumps(req_json).encode("utf-8")
-                    print(f"[{method}] /chat/completions: injected user={ARGO_USER} (model={req_json.get('model', '<not set>')})")
+                # Only mutate object bodies; valid non-object JSON (e.g. an array)
+                # is forwarded untouched rather than crashing the handler.
+                if not isinstance(req_json, dict):
+                    print(f"[{method}] /chat/completions: body is not a JSON object, forwarding as-is")
                 else:
-                    print(f"[{method}] /chat/completions: user already set ({req_json.get('user')})")
+                    existing = req_json.get("user")
+                    # Treat blank/whitespace user as missing — Argo rejects it.
+                    if not (isinstance(existing, str) and existing.strip()):
+                        req_json["user"] = ARGO_USER
+                        body = json.dumps(req_json).encode("utf-8")
+                        print(f"[{method}] /chat/completions: injected user={ARGO_USER} (model={req_json.get('model', '<not set>')})")
+                    else:
+                        print(f"[{method}] /chat/completions: user already set ({existing})")
             except (json.JSONDecodeError, UnicodeDecodeError):
                 print(f"[{method}] /chat/completions: could not parse body, forwarding as-is")
 

--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -19,6 +19,13 @@ import time
 TARGET_HOST = "127.0.0.1"
 REAL_HOST = "apps.inside.anl.gov"
 API_KEY = os.environ.get("CELS_USERNAME", getpass.getuser())
+
+# Argo's OpenAI-compatible /chat/completions endpoint (used for OpenAI and
+# Gemini models) requires a `user` field set to a valid ALCF username, or it
+# returns HTTP 500. The Anthropic /messages path does NOT need this. We
+# auto-inject it so OpenAI-format clients work without having to know about it.
+# Resolution mirrors API_KEY: $ARGO_USER, else $CELS_USERNAME, else login user.
+ARGO_USER = os.environ.get("ARGO_USER") or os.environ.get("CELS_USERNAME") or getpass.getuser()
 OPENCODE_CONFIG = os.path.expanduser("~/.config/opencode/opencode.json")
 STATE_PATH = os.path.expanduser("~/.claude/argo-shim-state.json")
 ACCOUNTS_URL = "https://accounts.cels.anl.gov"
@@ -443,6 +450,13 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
         # Validate auth token (HEAD is exempt — used by Claude Code as a connectivity probe)
         if self.server.auth_token:
             client_key = self.headers.get('x-api-key', '')
+            # Also accept `Authorization: Bearer <token>`, so OpenAI-format clients
+            # (which authenticate with a bearer token rather than x-api-key) can
+            # reach the shim too.
+            if not client_key:
+                auth_hdr = self.headers.get('Authorization', '')
+                if auth_hdr.lower().startswith('bearer '):
+                    client_key = auth_hdr[7:].strip()
             if method != "HEAD" and client_key != self.server.auth_token:
                 self.send_response(401)
                 self.send_header('Content-Type', 'text/plain')
@@ -501,6 +515,21 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                         body = json.dumps(req_json).encode("utf-8")
             except (json.JSONDecodeError, UnicodeDecodeError):
                 print(f"[{method}] /messages: could not parse body, forwarding as-is")
+
+        # Inject `user` on OpenAI/Gemini chat-completions requests. Argo returns
+        # HTTP 500 if the `user` field is missing or not a valid ALCF username.
+        # Only applies to /chat/completions (not /messages, which Claude uses).
+        if method == "POST" and body and "/chat/completions" in self.path:
+            try:
+                req_json = json.loads(body)
+                if not req_json.get("user"):
+                    req_json["user"] = ARGO_USER
+                    body = json.dumps(req_json).encode("utf-8")
+                    print(f"[{method}] /chat/completions: injected user={ARGO_USER} (model={req_json.get('model', '<not set>')})")
+                else:
+                    print(f"[{method}] /chat/completions: user already set ({req_json.get('user')})")
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                print(f"[{method}] /chat/completions: could not parse body, forwarding as-is")
 
         # Path rewrite logic
         path = self.path


### PR DESCRIPTION
## Summary

Two small, additive changes that let **OpenAI-format clients** and **OpenAI/Gemini models** work through the shim. Neither touches the Anthropic `/messages` path that Claude Code uses.

### 1. Accept `Authorization: Bearer <token>` for auth

The shim currently only accepts the token via `x-api-key`. OpenAI SDKs and OpenAI-compatible clients (e.g. OpenCode, Hermes, the OpenAI Python SDK) authenticate with `Authorization: Bearer <token>` and can't send `x-api-key`. This adds a fallback so those clients can authenticate, checked only if `x-api-key` is absent.

The bearer header is still stripped before forwarding upstream (it's already in the `_strip` set), so this only affects client→shim auth.

### 2. Auto-inject `user` for `/chat/completions`

Argo serves OpenAI and Gemini models on `/argoapi/v1/chat/completions`, but returns a bare **`HTTP 500`** unless the request body includes a `user` field set to a valid ALCF username. (The Anthropic `/messages` path does not require this.)

This auto-injects `user` for any `/chat/completions` request that doesn't already set it, so OpenAI-format clients work without needing to know about the quirk. The value resolves from `$ARGO_USER`, then `$CELS_USERNAME`, then the login username — mirroring how `API_KEY` is derived.

## Why

These came out of wiring up OpenAI-only desktop apps (OpenCode, Hermes One) to Argo through the shim. With both changes, GPT-4o / GPT-5 / o-series models work end-to-end via the shim; before, they returned 500 and bearer-auth clients got 401.

(Gemini still has a separate upstream Argo bug — `'NoneType' object is not iterable` — unrelated to these changes.)

## Testing

- Verified `GPT-4o` via `Authorization: Bearer <token>` with **no** `user` field returns a normal completion (previously 500 + 401).
- Verified Claude `/messages` (Claude Code path) is unaffected — bearer fallback only triggers when `x-api-key` is absent, and `user` injection is scoped to `/chat/completions`.
- `python -c "import ast; ast.parse(open('argo_shim/_shim.py').read())"` passes.

## Notes

- Both changes are guarded and scoped; no behavior change for existing `x-api-key` + `/messages` usage.
- README updated with a new "OpenAI-compatible clients" section documenting bearer auth and the `ARGO_USER` env var.