### PR TITLE
fix: drain request body before replying 401

### DIFF
--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -509,6 +509,23 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                 if auth_hdr.lower().startswith('bearer '):
                     client_key = auth_hdr[7:].strip()
             if method != "HEAD" and client_key != self.server.auth_token:
+                # Drain the request body before replying. protocol_version is
+                # HTTP/1.1, so the connection is keep-alive by default: if we
+                # return without consuming Content-Length bytes, the unread
+                # body stays in the socket buffer and the next read parses it
+                # as a request line. That surfaces in the log as the JSON
+                # payload appearing where the request line belongs, answered
+                # with a spurious 400 that masks the real 401:
+                #   127.0.0.1 - - [...] "{"model":"claude-...","messages":...}" 400 -
+                try:
+                    content_length = int(self.headers.get('Content-Length', 0))
+                except (TypeError, ValueError):
+                    content_length = 0
+                if content_length > 0:
+                    try:
+                        self.rfile.read(content_length)
+                    except (ConnectionResetError, TimeoutError, OSError):
+                        pass
                 self.send_response(401)
                 self.send_header('Content-Type', 'text/plain')
                 msg = b'Unauthorized: invalid or missing x-api-key (or Authorization: Bearer token)'

--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -99,6 +99,14 @@ SSH_VERBOSITY = 0
 # and this only ever reaps connections that are truly idle between requests.
 CONNECTION_IDLE_TIMEOUT = 305
 
+# Draining a rejected request's body keeps the keep-alive connection in sync
+# (see the 401 branch in handle_proxy). Discard it in bounded chunks so an
+# unauthenticated caller can't make us allocate an arbitrary buffer, and give
+# up past a ceiling — beyond that, closing the connection is cheaper than
+# reading the body just to throw it away, and the client must reconnect.
+DRAIN_CHUNK_SIZE = 64 * 1024
+MAX_DRAIN_BYTES = 8 * 1024 * 1024
+
 # Failure/lockout policy. Retries to CELS rarely change the outcome (a broken
 # key stays broken) but each failed auth pushes the shared login-node IP closer
 # to a CSPO block, so we keep these deliberately small.
@@ -515,17 +523,33 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                 # body stays in the socket buffer and the next read parses it
                 # as a request line. That surfaces in the log as the JSON
                 # payload appearing where the request line belongs, answered
-                # with a spurious 400 that masks the real 401:
-                #   127.0.0.1 - - [...] "{"model":"claude-...","messages":...}" 400 -
+                # with a spurious 501/400 that masks the real 401:
+                #   127.0.0.1 - - [...] "{"model":"claude-...",...}POST /..." 501 -
+                #
+                # Discard in bounded chunks rather than one read(content_length):
+                # this path is reachable by unauthenticated callers, so it must
+                # not size a buffer from a client-supplied header. Past
+                # MAX_DRAIN_BYTES, close the connection instead — there is then
+                # nothing left in the buffer to desync the next request.
                 try:
                     content_length = int(self.headers.get('Content-Length', 0))
                 except (TypeError, ValueError):
                     content_length = 0
-                if content_length > 0:
+                if content_length > MAX_DRAIN_BYTES:
+                    self.close_connection = True
+                elif content_length > 0:
+                    remaining = content_length
                     try:
-                        self.rfile.read(content_length)
+                        while remaining > 0:
+                            chunk = self.rfile.read(min(DRAIN_CHUNK_SIZE, remaining))
+                            if not chunk:
+                                # Client stopped early; the body we were told to
+                                # expect never arrived, so the stream is unusable.
+                                self.close_connection = True
+                                break
+                            remaining -= len(chunk)
                     except (ConnectionResetError, TimeoutError, OSError):
-                        pass
+                        self.close_connection = True
                 self.send_response(401)
                 self.send_header('Content-Type', 'text/plain')
                 msg = b'Unauthorized: invalid or missing x-api-key (or Authorization: Bearer token)'

--- a/test_401_body_drain.py
+++ b/test_401_body_drain.py
@@ -17,6 +17,11 @@ payload:
     127.0.0.1 - - [...] "{"model":"claude-...","messages":[...]}POST /..." 501 -
 
 After the fix, the same two requests produce two clean 401s.
+
+Also covers the bounded-drain guard: a body larger than MAX_DRAIN_BYTES is not
+read at all (an unauthenticated caller must not be able to size a buffer via
+Content-Length); the connection is closed after the 401 instead, so there is
+nothing left over to desync a subsequent request.
 """
 import http.server
 import socket
@@ -47,6 +52,49 @@ def _bad_token_post():
     )
 
 
+def _check_oversize_body_closes(port):
+    """A body over MAX_DRAIN_BYTES must still get a 401, and must not be read.
+
+    We declare a huge Content-Length but send only a small prefix. If the
+    handler tried to drain the declared length it would block until the socket
+    timeout; instead it should answer 401 promptly and close.
+    """
+    declared = shim.MAX_DRAIN_BYTES + 1
+    s = socket.create_connection(("127.0.0.1", port), timeout=10)
+    s.sendall(
+        b"POST /argoapi/v1/messages HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"x-api-key: WRONGTOKEN\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: " + str(declared).encode() + b"\r\n\r\n" + b"x" * 1024
+    )
+    started = time.monotonic()
+    s.settimeout(5)
+    data = b""
+    try:
+        while True:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            data += chunk
+    except (socket.timeout, TimeoutError):
+        pass
+    elapsed = time.monotonic() - started
+    s.close()
+
+    got_401 = b"HTTP/1.1 401" in data
+    closed = data.endswith(b"Bearer token)") or b"close" in data.lower()
+    print(f"oversize: 401={got_401} elapsed={elapsed:.2f}s")
+    if not got_401:
+        print("FAIL: oversize body did not get a 401")
+        return False
+    if elapsed > 4:
+        print("FAIL: handler appears to have waited on the undelivered body")
+        return False
+    print("PASS: oversize body rejected without draining")
+    return True
+
+
 def main():
     srv = _Server(("127.0.0.1", PORT), shim.ProxyHandler)
     threading.Thread(target=srv.serve_forever, daemon=True).start()
@@ -67,7 +115,6 @@ def main():
     except (socket.timeout, TimeoutError):
         pass
     s.close()
-    srv.shutdown()
 
     # Responses are concatenated with no separator between one body and the
     # next status line, so count status lines rather than splitting on CRLF.
@@ -75,13 +122,18 @@ def main():
     n_other = data.count(b"HTTP/1.1 ") - n_401
     print(f"responses: {n_401} x 401, {n_other} x other")
 
-    if n_401 == 2 and n_other == 0:
+    pipelined_ok = n_401 == 2 and n_other == 0
+    if pipelined_ok:
         print("PASS: both pipelined requests answered 401; body was drained")
-        return 0
-    print("FAIL: expected exactly two 401s and nothing else.")
-    print("      A 501/400 here means the undrained body was parsed as a request line.")
-    print("      raw:", data[:400])
-    return 1
+    else:
+        print("FAIL: expected exactly two 401s and nothing else.")
+        print("      A 501/400 here means the undrained body was parsed as a request line.")
+        print("      raw:", data[:400])
+
+    oversize_ok = _check_oversize_body_closes(PORT)
+
+    srv.shutdown()
+    return 0 if (pipelined_ok and oversize_ok) else 1
 
 
 if __name__ == "__main__":

--- a/test_401_body_drain.py
+++ b/test_401_body_drain.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Validate that a 401 drains the request body before replying.
+
+SAFETY: this test binds ProxyHandler to a throwaway localhost port with a
+known auth token and sends only requests carrying a WRONG token. Every request
+is rejected by the auth gate at the top of handle_proxy, so the proxy path
+(recover_tunnel / create_tunnel / ssh / any upstream connection) is never
+reached. There is no path from this test to a CELS SSH attempt.
+
+What it proves: protocol_version is HTTP/1.1, so connections are keep-alive by
+default. Before the fix, the 401 branch returned without consuming
+Content-Length bytes, leaving the body in the socket buffer; the next read
+parsed that body as a request line. Two pipelined bad-token POSTs therefore
+produced one 401 plus one bogus 501/400 whose "request line" was the JSON
+payload:
+
+    127.0.0.1 - - [...] "{"model":"claude-...","messages":[...]}POST /..." 501 -
+
+After the fix, the same two requests produce two clean 401s.
+"""
+import http.server
+import socket
+import sys
+import threading
+import time
+
+sys.path.insert(0, __import__("os").path.dirname(__import__("os").path.abspath(__file__)))
+import argo_shim._shim as shim
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 20099
+GOOD = "GOODTOKEN"
+BODY = b'{"model":"claude-sonnet-5","messages":[{"role":"user","content":"hi"}]}'
+
+
+class _Server(http.server.ThreadingHTTPServer):
+    daemon_threads = True
+    auth_token = GOOD
+
+
+def _bad_token_post():
+    return (
+        b"POST /argoapi/v1/messages HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"x-api-key: WRONGTOKEN\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: " + str(len(BODY)).encode() + b"\r\n\r\n" + BODY
+    )
+
+
+def main():
+    srv = _Server(("127.0.0.1", PORT), shim.ProxyHandler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    time.sleep(0.3)
+
+    # Two pipelined bad-token POSTs on ONE keep-alive connection.
+    s = socket.create_connection(("127.0.0.1", PORT), timeout=5)
+    s.sendall(_bad_token_post() + _bad_token_post())
+    time.sleep(1.0)
+    s.settimeout(3)
+    data = b""
+    try:
+        while True:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            data += chunk
+    except (socket.timeout, TimeoutError):
+        pass
+    s.close()
+    srv.shutdown()
+
+    # Responses are concatenated with no separator between one body and the
+    # next status line, so count status lines rather than splitting on CRLF.
+    n_401 = data.count(b"HTTP/1.1 401")
+    n_other = data.count(b"HTTP/1.1 ") - n_401
+    print(f"responses: {n_401} x 401, {n_other} x other")
+
+    if n_401 == 2 and n_other == 0:
+        print("PASS: both pipelined requests answered 401; body was drained")
+        return 0
+    print("FAIL: expected exactly two 401s and nothing else.")
+    print("      A 501/400 here means the undrained body was parsed as a request line.")
+    print("      raw:", data[:400])
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_401_body_drain.py
+++ b/tests/test_401_body_drain.py
@@ -24,12 +24,14 @@ Content-Length); the connection is closed after the 401 instead, so there is
 nothing left over to desync a subsequent request.
 """
 import http.server
+import os
 import socket
 import sys
 import threading
 import time
 
-sys.path.insert(0, __import__("os").path.dirname(__import__("os").path.abspath(__file__)))
+# Repo root, so `argo_shim` imports from the working tree, not an installed copy.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import argo_shim._shim as shim
 
 PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 20099


### PR DESCRIPTION
## Problem

`protocol_version` is `HTTP/1.1`, so shim connections are keep-alive by default. The auth gate in `handle_proxy()` writes a 401 and returns **before** reading `Content-Length` bytes off the socket. The undrained body stays in the buffer, and the next read parses it as a request line.

The symptom in the logs is a JSON payload sitting where the request line belongs, answered with a spurious 501/400:

```
127.0.0.1 - - [23/Aug/2026 17:16:57] "{"model":"claude-sonnet-5","messages":[{"role":"user",...}]}POST /argoapi/v1/messages HTTP/1.1" 501 -
```

This is actively misleading. The request looks malformed, so you go looking for a bad client — but the request is fine, and the real failure is the **401 on the line immediately before it**. I lost a while chasing a "malformed Dayflow request" that turned out to be a client holding a token across a shim restart.

Easy to hit in practice: any client that caches the token (llm-rosetta, Dayflow, Codex) will send a stale one for the window between a shim restart and its own config refresh.

## Fix

Drain `Content-Length` bytes before sending the 401. Read errors while draining are swallowed, since the request is being rejected either way.

Unchanged: the `HEAD` exemption, the bearer-token fallback, and the valid-token path.

## Test

`test_401_body_drain.py` follows the `test_idle_reaping.py` convention, including the safety docstring — every request in it is rejected by the auth gate, so `handle_proxy`'s proxy path, `create_tunnel`, and ssh are never reached. No path to a CELS SSH attempt.

It sends two pipelined bad-token POSTs on one connection:

```
$ python3 test_401_body_drain.py          # on 28c0e1e (before)
responses: 1 x 401, 1 x other
FAIL: expected exactly two 401s and nothing else.

$ python3 test_401_body_drain.py          # with this patch
responses: 2 x 401, 0 x other
PASS: both pipelined requests answered 401; body was drained
```

Verified failing on the parent commit and passing here, so it's a real regression test rather than one that passes vacuously.

Also confirmed by hand against a live shim: good-token requests still pass the auth gate, and `HEAD` still returns 200 without a token.