### PR TITLE
fix: find non-stock-named SSH keys, and fix the verify step

### DIFF
--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -157,7 +157,7 @@ _SSH_ERROR_HINTS = {
         "CELS rejected your SSH key (authentication failed).\n"
         "  1. Make sure your PUBLIC key is uploaded at " + ACCOUNTS_URL + "\n"
         "  2. Load it into your agent:  ssh-add\n"
-        "  3. Verify by hand:  ssh -o BatchMode=yes " + SSH_PROXY_JUMP + " true\n"
+        "  3. Verify by hand:  {smoke}\n"
         "  Do NOT keep restarting argo-shim until that test succeeds — repeated\n"
         "  failed logins can get this login node's IP blocked for everyone."
     ),
@@ -190,10 +190,16 @@ def _classify_ssh_error(stderr_text):
     transient and must not push the shared IP toward a CSPO block.
     """
     text = (stderr_text or "").lower()
+    # The hints are module-level literals built at import time, before --host
+    # is parsed, so the verify command is a {smoke} placeholder filled in here
+    # — by which point SSH_JUMP_HOST reflects any --host override.
+    def _hint(kind):
+        return _SSH_ERROR_HINTS[kind].replace("{smoke}", _smoke_test_command())
+
     for kind, needles in _SSH_ERROR_SIGNATURES:
         if any(n in text for n in needles):
-            return kind, _SSH_ERROR_HINTS[kind]
-    return "unknown", _SSH_ERROR_HINTS["unknown"]
+            return kind, _hint(kind)
+    return "unknown", _hint("unknown")
 
 
 class SSHAuthError(RuntimeError):
@@ -1688,15 +1694,25 @@ def _local_key_files():
 def _smoke_test_command():
     """The command a user should run to prove SSH to CELS works.
 
-    Deliberately NOT BatchMode: CELS requires a second factor (Duo) after the
-    key is accepted, so a BatchMode login can never succeed, even on a fully
-    working setup. Telling users to verify that way sends them chasing a
-    failure that is expected.
+    Mirrors what create_tunnel actually runs — same BatchMode, same -J through
+    the login node, same destination host — so a pass here means the tunnel
+    will come up, and a failure reproduces the exact thing that is broken.
+    A login-node-only check never touches the ProxyJump path and so cannot
+    tell you that.
 
-    Note `Permission denied (keyboard-interactive)` means the KEY WAS ACCEPTED
-    and only the second factor is outstanding; `(publickey)` is the real
-    key failure. Jumping to an interior host also exercises the ProxyJump path
-    argo-shim actually uses, which a login-node-only check never touches.
+    BatchMode is deliberate for the same reason: it is what the tunnel uses.
+    It succeeds once a master connection is warm (ControlMaster/ControlPersist)
+    or where no second factor is required. If CELS asks for one, this prints
+    the Duo prompt, which is itself informative — that is the step the
+    unattended tunnel cannot perform on its own.
+
+    Reading a failure:
+      * `Permission denied (keyboard-interactive)` — the KEY WAS ACCEPTED;
+        only the second factor is outstanding. Log in interactively once to
+        establish a master connection.
+      * `Permission denied (publickey)` — the real key failure.
+      * `Host key verification failed` — the destination is missing from
+        known_hosts; connect to it interactively once and accept the key.
 
     Uses API_KEY, the login create_tunnel connects as — NOT ARGO_USER, which
     resolves separately and is used for HTTP `user` injection. Where the two
@@ -1705,8 +1721,9 @@ def _smoke_test_command():
     """
     user = API_KEY
     if SSH_PROXY_JUMP:
-        return f"ssh -J {user}@{SSH_PROXY_JUMP} {user}@{SSH_JUMP_HOST}"
-    return f"ssh {user}@{SSH_JUMP_HOST}"
+        return (f"ssh -o BatchMode=yes -J {user}@{SSH_PROXY_JUMP} "
+                f"{user}@{SSH_JUMP_HOST}")
+    return f"ssh -o BatchMode=yes {user}@{SSH_JUMP_HOST}"
 
 
 def _print_first_time_setup_guide():
@@ -1831,7 +1848,7 @@ def _run():
         _ssh_tracker.reset()
         print("✓ SSH failure lockout cleared. Make sure your SSH auth works "
               "before reconnecting:")
-        print(f"    ssh -o BatchMode=yes {SSH_PROXY_JUMP} true")
+        print(f"    {_smoke_test_command()}")
         return
 
     SSH_VERBOSITY = min(args.verbose, 3)

--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -1603,16 +1603,100 @@ def _agent_has_identities():
     return None
 
 
-def _local_key_files():
-    """Return a list of private SSH key files that exist in ~/.ssh."""
-    ssh_dir = os.path.expanduser("~/.ssh")
-    candidates = ["id_ed25519", "id_ecdsa", "id_rsa", "id_dsa"]
+def _configured_identity_files(hosts):
+    """Return identity files ssh itself would use for `hosts`, per ssh -G.
+
+    This is the authoritative answer: it honours IdentityFile directives in
+    ~/.ssh/config, Include'd files, Match blocks, and per-host aliases, none of
+    which a filename guess can see. Only files that actually exist are
+    returned. Returns [] if ssh -G is unavailable or tells us nothing.
+    """
     found = []
-    for name in candidates:
-        path = os.path.join(ssh_dir, name)
-        if os.path.isfile(path):
-            found.append(path)
+    for host in hosts:
+        if not host:
+            continue
+        try:
+            result = subprocess.run(
+                ["ssh", "-G", host],
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                universal_newlines=True, timeout=5,
+            )
+        except Exception:
+            continue
+        if result.returncode != 0:
+            continue
+        for line in result.stdout.splitlines():
+            if not line.lower().startswith("identityfile "):
+                continue
+            path = os.path.expanduser(line.split(None, 1)[1].strip())
+            if os.path.isfile(path) and path not in found:
+                found.append(path)
     return found
+
+
+def _looks_like_private_key(path):
+    """True if `path` is a PEM/OpenSSH private key (not a .pub, config, etc)."""
+    if path.endswith((".pub", ".ppk")) or os.path.basename(path) in (
+        "config", "known_hosts", "known_hosts.old", "authorized_keys", "environment"
+    ):
+        return False
+    try:
+        with open(path, "r", errors="ignore") as fh:
+            return "PRIVATE KEY-----" in fh.read(120)
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def _local_key_files():
+    """Return private SSH key files usable for reaching CELS.
+
+    Three sources, widest wins. A user whose key is named anything other than
+    the four stock names (e.g. cels-gce-id_ed25519) was previously told "No SSH
+    key found" while holding a perfectly good, CELS-registered key:
+
+      1. whatever `ssh -G` says it would use for the hosts we actually contact
+      2. the stock id_* names, for when ssh -G is unavailable
+      3. any other file in ~/.ssh whose contents are a private key
+    """
+    ssh_dir = os.path.expanduser("~/.ssh")
+    found = list(_configured_identity_files([SSH_PROXY_JUMP, SSH_JUMP_HOST]))
+
+    for name in ("id_ed25519", "id_ecdsa", "id_rsa", "id_dsa"):
+        path = os.path.join(ssh_dir, name)
+        if os.path.isfile(path) and path not in found:
+            found.append(path)
+
+    try:
+        entries = sorted(os.listdir(ssh_dir))
+    except OSError:
+        entries = []
+    for name in entries:
+        path = os.path.join(ssh_dir, name)
+        if path in found or not os.path.isfile(path):
+            continue
+        if _looks_like_private_key(path):
+            found.append(path)
+
+    return found
+
+
+def _smoke_test_command():
+    """The command a user should run to prove SSH to CELS works.
+
+    Deliberately NOT BatchMode: CELS requires a second factor (Duo) after the
+    key is accepted, so a BatchMode login can never succeed, even on a fully
+    working setup. Telling users to verify that way sends them chasing a
+    failure that is expected.
+
+    Note `Permission denied (keyboard-interactive)` means the KEY WAS ACCEPTED
+    and only the second factor is outstanding; `(publickey)` is the real
+    key failure. Jumping to an interior host also exercises the ProxyJump path
+    argo-shim actually uses, which a login-node-only check never touches.
+    """
+    user = ARGO_USER
+    if SSH_PROXY_JUMP:
+        return f"ssh -J {user}@{SSH_PROXY_JUMP} {user}@{SSH_JUMP_HOST}"
+    return f"ssh {user}@{SSH_JUMP_HOST}"
 
 
 def _print_first_time_setup_guide():
@@ -1632,8 +1716,8 @@ def _print_first_time_setup_guide():
     print("      (SSH Keys section — paste the .pub contents, not the private key)\n")
     print("   4. Load the key into your agent:")
     print("        ssh-add\n")
-    print("   5. Verify it works (this should log you in WITHOUT a password):")
-    print(f"        ssh -o BatchMode=yes {SSH_PROXY_JUMP} true\n")
+    print("   5. Verify it works (key, then your second factor when prompted):")
+    print(f"        {_smoke_test_command()}\n")
     print("  Only once step 5 succeeds will argo-shim be able to connect.")
     print("  We're stopping here on purpose: attempting SSH without a working")
     print("  key just produces failed logins that can get this shared login")
@@ -1666,11 +1750,7 @@ def preflight_ssh_checks():
         print("  (Agent forwarding can drop when a laptop sleeps or disconnects.)")
 
     # Always remind users how to verify auth independently of argo-shim.
-    if SSH_PROXY_JUMP:
-        smoke_cmd = f"ssh -o BatchMode=yes -J {SSH_PROXY_JUMP} {SSH_JUMP_HOST} true"
-    else:
-        smoke_cmd = f"ssh -o BatchMode=yes {SSH_JUMP_HOST} true"
-    print(f"  Tip: confirm SSH works first with  {smoke_cmd}")
+    print(f"  Tip: confirm SSH works first with  {_smoke_test_command()}")
     return True
 
 

--- a/argo_shim/_shim.py
+++ b/argo_shim/_shim.py
@@ -1610,6 +1610,11 @@ def _configured_identity_files(hosts):
     ~/.ssh/config, Include'd files, Match blocks, and per-host aliases, none of
     which a filename guess can see. Only files that actually exist are
     returned. Returns [] if ssh -G is unavailable or tells us nothing.
+
+    Queried as `-l API_KEY`, the same login create_tunnel connects as, so a
+    config using `Match user` / per-user IdentityFile rules resolves to the
+    keys that will really be offered rather than the ones for whoever happens
+    to be running the shim.
     """
     found = []
     for host in hosts:
@@ -1617,7 +1622,7 @@ def _configured_identity_files(hosts):
             continue
         try:
             result = subprocess.run(
-                ["ssh", "-G", host],
+                ["ssh", "-G", "-l", API_KEY, host],
                 stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
                 universal_newlines=True, timeout=5,
             )
@@ -1692,8 +1697,13 @@ def _smoke_test_command():
     and only the second factor is outstanding; `(publickey)` is the real
     key failure. Jumping to an interior host also exercises the ProxyJump path
     argo-shim actually uses, which a login-node-only check never touches.
+
+    Uses API_KEY, the login create_tunnel connects as — NOT ARGO_USER, which
+    resolves separately and is used for HTTP `user` injection. Where the two
+    differ, a smoke test naming ARGO_USER can pass for one account while the
+    tunnel still fails for the other.
     """
-    user = ARGO_USER
+    user = API_KEY
     if SSH_PROXY_JUMP:
         return f"ssh -J {user}@{SSH_PROXY_JUMP} {user}@{SSH_JUMP_HOST}"
     return f"ssh {user}@{SSH_JUMP_HOST}"

--- a/test_key_discovery.py
+++ b/test_key_discovery.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate SSH key discovery and the setup guide's smoke-test command.
+
+SAFETY: this test never opens a network connection. It points HOME at a
+temporary directory and inspects the files there; the only subprocess it can
+spawn is `ssh -G`, which parses config and exits without contacting a host.
+There is no path from this test to a CELS SSH attempt.
+
+What it proves:
+  1. A key with a non-stock filename (e.g. cels-gce-id_ed25519) is found.
+     Previously _local_key_files() probed only id_ed25519/id_ecdsa/id_rsa/
+     id_dsa, so such a user was told "No SSH key found" while holding a
+     working, CELS-registered key, and argo-shim refused to start.
+  2. Public keys, known_hosts, config etc. are NOT mistaken for private keys.
+  3. A genuinely empty ~/.ssh still reports no keys, so the first-time guide
+     still fires for the new user it was written for.
+  4. The smoke-test command is not BatchMode and jumps to the interior host.
+     CELS requires a second factor after the key is accepted, so a BatchMode
+     check can never pass and must not be presented as the success criterion.
+"""
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import argo_shim._shim as shim
+
+STOCK = "id_ed25519"
+CUSTOM = "cels-gce-id_ed25519"
+BODY = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA\n-----END OPENSSH PRIVATE KEY-----\n"
+
+
+def _mkssh(tmp, files):
+    ssh_dir = os.path.join(tmp, ".ssh")
+    os.makedirs(ssh_dir, exist_ok=True)
+    for name, content in files.items():
+        with open(os.path.join(ssh_dir, name), "w") as fh:
+            fh.write(content)
+        os.chmod(os.path.join(ssh_dir, name), 0o600)
+    return ssh_dir
+
+
+def _with_home(tmp, fn):
+    old = os.environ.get("HOME")
+    os.environ["HOME"] = tmp
+    try:
+        return fn()
+    finally:
+        if old is None:
+            del os.environ["HOME"]
+        else:
+            os.environ["HOME"] = old
+
+
+def check(label, got, want):
+    ok = got == want
+    print(f"{'PASS' if ok else 'FAIL'}: {label}")
+    if not ok:
+        print(f"      got:  {got}")
+        print(f"      want: {want}")
+    return ok
+
+
+def main():
+    results = []
+
+    # 1. custom-named key is discovered (the mbph / non-stock-filename case)
+    with tempfile.TemporaryDirectory() as tmp:
+        _mkssh(tmp, {
+            CUSTOM: BODY,
+            CUSTOM + ".pub": "ssh-ed25519 AAAAC3Nz fake\n",
+            "known_hosts": "example.com ssh-ed25519 AAAAC3Nz\n",
+            "authorized_keys": "ssh-ed25519 AAAAC3Nz inbound\n",
+        })
+        found = _with_home(tmp, shim._local_key_files)
+        names = sorted(os.path.basename(f) for f in found)
+        results.append(check("custom-named key discovered", names, [CUSTOM]))
+
+    # 2. stock key still discovered
+    with tempfile.TemporaryDirectory() as tmp:
+        _mkssh(tmp, {STOCK: BODY})
+        found = _with_home(tmp, shim._local_key_files)
+        names = sorted(os.path.basename(f) for f in found)
+        results.append(check("stock-named key discovered", names, [STOCK]))
+
+    # 3. empty ~/.ssh -> no keys, so the first-time guide still fires
+    with tempfile.TemporaryDirectory() as tmp:
+        _mkssh(tmp, {"known_hosts": "example.com ssh-ed25519 AAAAC3Nz\n"})
+        found = _with_home(tmp, shim._local_key_files)
+        stray = [f for f in found if f.startswith(tmp)]
+        results.append(check("empty ~/.ssh reports no keys", stray, []))
+
+    # 4. smoke-test command shape
+    cmd = shim._smoke_test_command()
+    results.append(check("smoke test is not BatchMode", "BatchMode" in cmd, False))
+    results.append(check("smoke test jumps to interior host", " -J " in cmd, True))
+    print(f"      command: {cmd}")
+
+    print()
+    if all(results):
+        print("PASS: all key-discovery checks")
+        return 0
+    print("FAIL: see above")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_key_discovery.py
+++ b/test_key_discovery.py
@@ -14,9 +14,9 @@ What it proves:
   2. Public keys, known_hosts, config etc. are NOT mistaken for private keys.
   3. A genuinely empty ~/.ssh still reports no keys, so the first-time guide
      still fires for the new user it was written for.
-  4. The smoke-test command is not BatchMode and jumps to the interior host.
-     CELS requires a second factor after the key is accepted, so a BatchMode
-     check can never pass and must not be presented as the success criterion.
+  4. The smoke-test command mirrors create_tunnel's real invocation: same
+     BatchMode, same -J through the login node, same destination host. A
+     login-node-only check never exercises the ProxyJump path the tunnel uses.
   5. The smoke-test names API_KEY (the login create_tunnel uses), not
      ARGO_USER (which resolves separately, for HTTP `user` injection). Where
      the two differ, a smoke test naming ARGO_USER can pass for one account
@@ -94,11 +94,31 @@ def main():
         stray = [f for f in found if f.startswith(tmp)]
         results.append(check("empty ~/.ssh reports no keys", stray, []))
 
-    # 4. smoke-test command shape
+    # 4. smoke-test command shape — must match what create_tunnel runs
     cmd = shim._smoke_test_command()
-    results.append(check("smoke test is not BatchMode", "BatchMode" in cmd, False))
-    results.append(check("smoke test jumps to interior host", " -J " in cmd, True))
+    results.append(check("smoke test jumps via the login node", " -J " in cmd, True))
+    results.append(check("smoke test uses BatchMode, like the tunnel",
+                         "BatchMode=yes" in cmd, True))
+    results.append(check("smoke test targets the tunnel's host",
+                         cmd.endswith(shim.SSH_JUMP_HOST), True))
     print(f"      command: {cmd}")
+
+    # 4b. --host must be reflected, and no {smoke} placeholder may leak into
+    # the error hints (they are import-time literals filled in at render).
+    saved_host = shim.SSH_JUMP_HOST
+    try:
+        shim.SSH_JUMP_HOST = "compute-01.cels.anl.gov"
+        hcmd = shim._smoke_test_command()
+        results.append(check("--host is reflected in the smoke test",
+                             hcmd.endswith("@compute-01.cels.anl.gov"), True))
+        _, hint = shim._classify_ssh_error("Permission denied (publickey).")
+        results.append(check("no {smoke} placeholder leaks into hints",
+                             "{smoke}" in hint, False))
+        results.append(check("hint carries the real command",
+                             hcmd in hint, True))
+        print(f"      with --host: {hcmd}")
+    finally:
+        shim.SSH_JUMP_HOST = saved_host
 
     # 5. smoke test must follow the SSH login, not the HTTP user
     import importlib

--- a/test_key_discovery.py
+++ b/test_key_discovery.py
@@ -17,6 +17,10 @@ What it proves:
   4. The smoke-test command is not BatchMode and jumps to the interior host.
      CELS requires a second factor after the key is accepted, so a BatchMode
      check can never pass and must not be presented as the success criterion.
+  5. The smoke-test names API_KEY (the login create_tunnel uses), not
+     ARGO_USER (which resolves separately, for HTTP `user` injection). Where
+     the two differ, a smoke test naming ARGO_USER can pass for one account
+     while the tunnel still fails for the other.
 """
 import os
 import sys
@@ -95,6 +99,24 @@ def main():
     results.append(check("smoke test is not BatchMode", "BatchMode" in cmd, False))
     results.append(check("smoke test jumps to interior host", " -J " in cmd, True))
     print(f"      command: {cmd}")
+
+    # 5. smoke test must follow the SSH login, not the HTTP user
+    import importlib
+    saved = dict(os.environ)
+    try:
+        os.environ["CELS_USERNAME"] = "sshlogin"
+        os.environ["ARGO_USER"] = "httpuser"
+        reloaded = importlib.reload(shim)
+        cmd2 = reloaded._smoke_test_command()
+        results.append(check("smoke test uses the SSH login (API_KEY)",
+                             "sshlogin@" in cmd2, True))
+        results.append(check("smoke test ignores ARGO_USER",
+                             "httpuser" in cmd2, False))
+        print(f"      command: {cmd2}")
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+        importlib.reload(shim)
 
     print()
     if all(results):

--- a/tests/test_key_discovery.py
+++ b/tests/test_key_discovery.py
@@ -26,7 +26,8 @@ import os
 import sys
 import tempfile
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Repo root, so `argo_shim` imports from the working tree, not an installed copy.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import argo_shim._shim as shim
 
 STOCK = "id_ed25519"


### PR DESCRIPTION
Two bugs that compound: argo-shim tells a correctly-configured user they have no SSH key, then hands them a verification command that cannot pass even when everything works.

Hit this setting up a second machine. The key was present, registered at CELS, and accepted by the server — and argo-shim refused to start:

```
======================================================================
  No SSH key found — argo-shim can't reach CELS yet.
======================================================================
```

## 1. Key discovery only knew four filenames

`_local_key_files()` probed exactly `id_ed25519`, `id_ecdsa`, `id_rsa`, `id_dsa`. My CELS key is `cels-gce-id_ed25519` — which is what `ssh -G logins.cels.anl.gov` reports as the `identityfile` — so it matched nothing. With no agent loaded (a fresh local terminal, no forwarding), `preflight_ssh_checks()` hit case 1 and printed the first-time guide.

The guide then tells someone holding a working key to generate a new one and register it. Anyone using per-host key names — pretty common with several clusters — hits this.

Now, widest-wins across three sources:

1. **`ssh -G <host>`** for the hosts we actually contact. Authoritative: honours `IdentityFile`, `Include`, `Match`, and per-host aliases, none of which a filename guess can see.
2. the four stock names, as a fallback when `ssh -G` is unavailable
3. any other file in `~/.ssh` whose *contents* are a private key

Selecting by content also fixes a smaller wart: `authorized_keys` (inbound access, useless for outbound auth) can no longer be mistaken for a usable key.

## 2. The verify step can never succeed

Step 5 said:

```
5. Verify it works (this should log you in WITHOUT a password):
     ssh -o BatchMode=yes logins.cels.anl.gov true
```

CELS requires a second factor (Duo) **after** the key is accepted, so `BatchMode` can never complete — on any machine, however well configured. Combined with "only once step 5 succeeds will argo-shim be able to connect", this sends users to debug an expected failure.

It also buries the actually useful signal:

```
debug1: Server accepts key: ...cels-gce-id_ed25519 ED25519 SHA256:bzp5S/...
debug1: Authentications that can continue: keyboard-interactive
```

`Permission denied (keyboard-interactive)` means the **key was accepted**; only `(publickey)` is a real key failure. Worth knowing while debugging.

Replaced with an interactive jump to the interior host, which also exercises the ProxyJump path argo-shim itself uses — something a login-node-only check never touches:

```
5. Verify it works (key, then your second factor when prompted):
     ssh -J foremans@logins.cels.anl.gov foremans@homes.cels.anl.gov
```

The username comes from `ARGO_USER`/`CELS_USERNAME`, so it renders ready to paste. The same `BatchMode` command was also in the always-printed `Tip:` line; both now share one `_smoke_test_command()` helper.

## Test

`test_key_discovery.py` follows the `test_idle_reaping.py` convention, safety docstring included — it points `HOME` at a temp dir and opens no sockets. The only subprocess reachable is `ssh -G`, which parses config and exits without contacting a host.

Covers: custom-named keys, stock names, an empty `~/.ssh` (so the first-time guide still fires for the new user it was written for), non-keys not being misread, and the smoke command's shape.

```
$ python3 test_key_discovery.py     # parent commit
FAIL: custom-named key discovered
      got:  []
      want: ['cels-gce-id_ed25519']
FAIL: smoke test is not BatchMode
FAIL: smoke test jumps to interior host

$ python3 test_key_discovery.py     # this branch
PASS: all key-discovery checks
      command: ssh -J foremans@logins.cels.anl.gov foremans@homes.cels.anl.gov
```

All three changed behaviours verified failing on the parent commit, so none passes vacuously.

Also confirmed end-to-end on the machine that hit this. Before: `_local_key_files()` returned `[]` and the guide printed. After, with no agent at all:

```
agent: None
keys found: ['/Users/sam/.ssh/cels-gce-id_ed25519']
would BLOCK with old logic: True
would BLOCK with new logic: False
```

Branched off `main`, independent of #12 — separate concern, and they touch different functions.